### PR TITLE
Include pysam dependency for AIVariant Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,15 +5,16 @@ FROM python:3.10-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     build-essential \
+    samtools \
     && rm -rf /var/lib/apt/lists/*
 
-# Clone the AIVariant repository
-RUN git clone https://github.com/Genome4me/AIVariant /opt/AIVariant
+# Copy the AIVariant repository into the image
+WORKDIR /opt/AIVariant
+COPY . /opt/AIVariant
 
 # Install Python dependencies
-WORKDIR /opt/AIVariant
 RUN pip install --no-cache-dir --upgrade pip \
-    && if [ -f requirements.txt ]; then pip install --no-cache-dir -r requirements.txt || true; fi
+    && pip install --no-cache-dir -r requirements.txt
 
 # Default command will run the main script
 WORKDIR /opt/AIVariant/AIVariant

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+numpy
+pyBigWig
+pysam
+liftover


### PR DESCRIPTION
## Summary
- install samtools and Python requirements (numpy, pyBigWig, pysam, liftover) in Docker image
- copy repository into the image so Docker build uses local code

## Testing
- ⚠️ `docker build -t aivariant:test .` *(Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*

------
https://chatgpt.com/codex/tasks/task_e_68ac10879e2c8331b3ef750430f32a69