### PR TITLE
feat: add ubuntu-based container with conda envs

### DIFF
--- a/AIVariant/run.sh
+++ b/AIVariant/run.sh
@@ -1,33 +1,35 @@
 #!/bin/bash
 
-while getopts i:e:t:n:r:o:g:d: flag
-do
+while getopts i:e:t:n:r:o:g:d: flag; do
     case "${flag}" in
-        i) input_env=${OPTARG};;
-        e) eval_env=${OPTARG};;
-        t) tumor=${OPTARG};;
-        n) normal=${OPTARG};;
-        r) reference=${OPTARG};;
-        o) outdir=${OPTARG};;
-        g) hg=${OPTARG};;
-        d) depth=${OPTARG};;
-    esac 
-done 
+        i) input_env=${OPTARG} ;;
+        e) eval_env=${OPTARG} ;;
+        t) tumor=${OPTARG} ;;
+        n) normal=${OPTARG} ;;
+        r) reference=${OPTARG} ;;
+        o) outdir=${OPTARG} ;;
+        g) hg=${OPTARG} ;;
+        d) depth=${OPTARG} ;;
+    esac
+done
 
-source activate base;
+set -e
 
-binpath=$CONDA_PREFIX/bin;
+source /opt/conda/etc/profile.d/conda.sh
+conda activate base
 
-echo $binpath
+binpath=$CONDA_PREFIX/bin
+echo "$binpath"
 
-source $binpath/deactivate;
-source $binpath/activate $input_env;
+conda deactivate
+conda activate "$input_env"
 
-python generate_input.py -t $tumor -n $normal -r $reference -o $outdir -g $hg -d $depth;
+python generate_input.py -t "$tumor" -n "$normal" -r "$reference" -o "$outdir" -g "$hg" -d "$depth"
 
-source $binpath/deactivate;
-source $binpath/activate $eval_env;
+conda deactivate
+conda activate "$eval_env"
 
-python evaluate.py -t $tumor -n $normal -r $reference -o $outdir -g $hg -d $depth;
+python evaluate.py -t "$tumor" -n "$normal" -r "$reference" -o "$outdir" -g "$hg" -d "$depth"
 
-source $binpath/deactivate;
+conda deactivate
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,32 @@
-# Use an official Python runtime as a parent image
-FROM python:3.10-slim
+FROM ubuntu:22.04
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    wget \
     git \
+    bzip2 \
+    ca-certificates \
     build-essential \
     samtools \
     && rm -rf /var/lib/apt/lists/*
 
+# Install Miniconda
+RUN wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /tmp/miniconda.sh && \
+    bash /tmp/miniconda.sh -b -p /opt/conda && \
+    rm /tmp/miniconda.sh
+ENV PATH=/opt/conda/bin:$PATH
+
+# Create conda environments
+RUN conda update -n base -y && \
+    conda create -y -n input_env python=3.10 numpy pybigwig pysam liftover && \
+    conda create -y -n eval_env python=3.10 numpy pybigwig pysam liftover tensorflow keras && \
+    conda clean -afy
+
 # Copy the AIVariant repository into the image
 WORKDIR /opt/AIVariant
 COPY . /opt/AIVariant
+RUN chmod +x AIVariant/run.sh
 
-# Install Python dependencies
-RUN pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir -r requirements.txt
-
-# Default command will run the main script
+# Default command will run the workflow script
 WORKDIR /opt/AIVariant/AIVariant
-ENTRYPOINT ["python", "main.py"]
-CMD ["--help"]
+ENTRYPOINT ["/opt/AIVariant/AIVariant/run.sh"]


### PR DESCRIPTION
## Summary
- base container on Ubuntu 22.04 and install Miniconda
- create `input_env` and `eval_env` conda environments and run workflow via `run.sh`
- update `run.sh` to use modern `conda` activation

## Testing
- `bash -n AIVariant/run.sh`
- `python -m py_compile AIVariant/generate_input.py AIVariant/evaluate.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac16ee530483318f3b2235abf48511